### PR TITLE
Optimize Diago_DavSubspace with GPU operators by adding and fusing ing custom kernels.

### DIFF
--- a/source/module_base/module_device/cuda/memory_op.cu
+++ b/source/module_base/module_device/cuda/memory_op.cu
@@ -61,6 +61,17 @@ void set_memory_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_devic
 }
 
 template <typename FPTYPE>
+void set_memory_2d_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* dev,
+                                                                   FPTYPE* arr,
+                                                                   const size_t pitch,
+                                                                   const int var,
+                                                                   const size_t width,
+                                                                   const size_t height)
+{
+    cudaErrcheck(cudaMemset2D(arr, sizeof(FPTYPE) * pitch , var, sizeof(FPTYPE) * width, height));
+}
+
+template <typename FPTYPE>
 void synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_GPU>::operator()(
     const base_device::DEVICE_CPU* dev_out,
     const base_device::DEVICE_GPU* dev_in,
@@ -91,6 +102,48 @@ void synchronize_memory_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_
     const size_t size)
 {
     cudaErrcheck(cudaMemcpy(arr_out, arr_in, sizeof(FPTYPE) * size, cudaMemcpyDeviceToDevice));
+}
+
+template <typename FPTYPE>
+void synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_GPU>::operator()(
+    const base_device::DEVICE_CPU* dev_out,
+    const base_device::DEVICE_GPU* dev_in,
+    FPTYPE* arr_out,
+    const size_t dpitch,
+    const FPTYPE* arr_in,
+    const size_t spitch,
+    const size_t width,
+    const size_t height)
+{
+    cudaErrcheck(cudaMemcpy2D(arr_out, dpitch * sizeof(FPTYPE), arr_in, spitch * sizeof(FPTYPE), width * sizeof(FPTYPE), height, cudaMemcpyDeviceToHost));
+}
+
+template <typename FPTYPE>
+void synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_CPU>::operator()(
+    const base_device::DEVICE_GPU* dev_out,
+    const base_device::DEVICE_CPU* dev_in,
+    FPTYPE* arr_out,
+    const size_t dpitch,
+    const FPTYPE* arr_in,
+    const size_t spitch,
+    const size_t width,
+    const size_t height)
+{
+    cudaErrcheck(cudaMemcpy2D(arr_out, dpitch * sizeof(FPTYPE), arr_in, spitch * sizeof(FPTYPE), width * sizeof(FPTYPE), height, cudaMemcpyHostToDevice));
+}
+
+template <typename FPTYPE>
+void synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_GPU>::operator()(
+    const base_device::DEVICE_GPU* dev_out,
+    const base_device::DEVICE_GPU* dev_in,
+    FPTYPE* arr_out,
+    const size_t dpitch,
+    const FPTYPE* arr_in,
+    const size_t spitch,
+    const size_t width,
+    const size_t height)
+{
+    cudaErrcheck(cudaMemcpy2D(arr_out, dpitch * sizeof(FPTYPE), arr_in, spitch * sizeof(FPTYPE), width * sizeof(FPTYPE), height, cudaMemcpyDeviceToDevice));
 }
 
 template <typename FPTYPE_out, typename FPTYPE_in>
@@ -180,12 +233,19 @@ template struct resize_memory_op<float, base_device::DEVICE_GPU>;
 template struct resize_memory_op<double, base_device::DEVICE_GPU>;
 template struct resize_memory_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct resize_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct resize_memory_op<char, base_device::DEVICE_GPU>;
 
 template struct set_memory_op<int, base_device::DEVICE_GPU>;
 template struct set_memory_op<float, base_device::DEVICE_GPU>;
 template struct set_memory_op<double, base_device::DEVICE_GPU>;
 template struct set_memory_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct set_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
+
+template struct set_memory_2d_op<int, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<float, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<double, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU>;
 
 template struct synchronize_memory_op<int, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 template struct synchronize_memory_op<int, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
@@ -202,6 +262,22 @@ template struct synchronize_memory_op<std::complex<float>, base_device::DEVICE_G
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
 
 template struct cast_memory_op<float, float, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
 template struct cast_memory_op<double, double, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
@@ -269,6 +345,7 @@ template struct delete_memory_op<float, base_device::DEVICE_GPU>;
 template struct delete_memory_op<double, base_device::DEVICE_GPU>;
 template struct delete_memory_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct delete_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct delete_memory_op<char, base_device::DEVICE_GPU>;
 template struct delete_memory_op<float*, base_device::DEVICE_GPU>;
 template struct delete_memory_op<double*, base_device::DEVICE_GPU>;
 template struct delete_memory_op<std::complex<float>*, base_device::DEVICE_GPU>;

--- a/source/module_base/module_device/memory_op.cpp
+++ b/source/module_base/module_device/memory_op.cpp
@@ -52,6 +52,18 @@ struct set_memory_op<FPTYPE, base_device::DEVICE_CPU>
 };
 
 template <typename FPTYPE>
+struct set_memory_2d_op<FPTYPE, base_device::DEVICE_CPU>
+{
+    void operator()(const base_device::DEVICE_CPU* dev, FPTYPE* arr, const size_t pitch, const int var, const size_t width, const size_t height)
+    {
+        for (size_t i = 0; i < height; i++){
+            set_memory_op<FPTYPE, base_device::DEVICE_CPU>()(dev, arr + i * pitch, var, width);
+        }
+    }
+};
+
+
+template <typename FPTYPE>
 struct synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_CPU>
 {
     void operator()(const base_device::DEVICE_CPU* dev_out,
@@ -65,6 +77,25 @@ struct synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVIC
             ModuleBase::BLOCK_TASK_DIST_1D(num_thread, thread_id, size, (size_t)4096 / sizeof(FPTYPE), beg, len);
             memcpy(arr_out + beg, arr_in + beg, sizeof(FPTYPE) * len);
         });
+    }
+};
+
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_CPU>
+{
+    void operator()(const base_device::DEVICE_CPU* dev_out,
+                    const base_device::DEVICE_CPU* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height)
+    {
+        for (int i = 0; i < height; i++){
+            synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_CPU>()(dev_out, dev_in,
+            arr_out + i * dpitch, arr_in + i * spitch, width);
+        }
     }
 };
 
@@ -108,11 +139,23 @@ template struct set_memory_op<double, base_device::DEVICE_CPU>;
 template struct set_memory_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct set_memory_op<std::complex<double>, base_device::DEVICE_CPU>;
 
+template struct set_memory_2d_op<int, base_device::DEVICE_CPU>;
+template struct set_memory_2d_op<float, base_device::DEVICE_CPU>;
+template struct set_memory_2d_op<double, base_device::DEVICE_CPU>;
+template struct set_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU>;
+template struct set_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU>;
+
 template struct synchronize_memory_op<int, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<float, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<double, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 
 template struct cast_memory_op<float, float, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 template struct cast_memory_op<double, double, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
@@ -165,6 +208,13 @@ struct set_memory_op<FPTYPE, base_device::DEVICE_GPU>
     {
     }
 };
+template <typename FPTYPE>
+struct set_memory_2d_op<FPTYPE, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev, FPTYPE* arr, const size_t pitch, const int var, const size_t width, const size_t height)
+    {
+    }
+};
 
 template <typename FPTYPE>
 struct synchronize_memory_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_GPU>
@@ -198,6 +248,54 @@ struct synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVIC
                     FPTYPE* arr_out,
                     const FPTYPE* arr_in,
                     const size_t size)
+    {
+    }
+};
+
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev_out,
+                    const base_device::DEVICE_GPU* dev_in,
+                    const Device_in* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height)
+    {
+    }
+};
+
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_CPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev_out,
+                    const base_device::DEVICE_CPU* dev_in,
+                    const Device_in* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height)
+    {
+    }
+};
+
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_CPU* dev_out,
+                    const base_device::DEVICE_GPU* dev_in,
+                    const Device_in* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height)
     {
     }
 };
@@ -258,6 +356,12 @@ template struct set_memory_op<double, base_device::DEVICE_GPU>;
 template struct set_memory_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct set_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
 
+template struct set_memory_2d_op<int, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<float, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<double, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU>;
+template struct set_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU>;
+
 template struct synchronize_memory_op<int, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 template struct synchronize_memory_op<int, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<int, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
@@ -273,6 +377,22 @@ template struct synchronize_memory_op<std::complex<float>, base_device::DEVICE_G
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
 template struct synchronize_memory_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<int, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<float, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<double, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+template struct synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
 
 template struct cast_memory_op<float, float, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;
 template struct cast_memory_op<double, double, base_device::DEVICE_GPU, base_device::DEVICE_GPU>;

--- a/source/module_base/module_device/memory_op.h
+++ b/source/module_base/module_device/memory_op.h
@@ -42,6 +42,23 @@ struct set_memory_op
     void operator()(const Device* dev, FPTYPE* arr, const int var, const size_t size);
 };
 
+template <typename FPTYPE, typename Device>
+struct set_memory_2d_op
+{
+    /// @brief memset2D for multi-device
+    ///
+    /// Input Parameters
+    /// \param dev : the type of computing device
+    /// \param var : the specified constant value
+    /// \param pitch : Pitch in elements  of 2D device memory
+    /// \param width : Width of matrix set (columns in elements)
+    /// \param height : Height of matrix set (rows)
+    ///
+    /// Output Parameters
+    /// \param arr : output array initialized by the input value
+    void operator()(const Device* dev, FPTYPE* arr, const size_t pitch, const int var, const size_t width, const size_t height);
+};
+
 template <typename FPTYPE, typename Device_out, typename Device_in>
 struct synchronize_memory_op
 {
@@ -60,6 +77,32 @@ struct synchronize_memory_op
                     FPTYPE* arr_out,
                     const FPTYPE* arr_in,
                     const size_t size);
+};
+
+template <typename FPTYPE, typename Device_out, typename Device_in>
+struct synchronize_memory_2d_op
+{
+    /// @brief memcpy2D for multi-device
+    ///
+    /// Input Parameters
+    /// \param dev_out : the type of computing device of arr_out
+    /// \param dev_in : the type of computing device of arr_in
+    /// \param arr_in : input array
+    /// \param dpitch : Pitch in elements of destination memory
+    /// \param spitch : Pitch in elements  of source memory
+    /// \param width : Width of matrix transfer (columns in elements)
+    /// \param height : Height of matrix transfer (rows)
+    ///
+    /// Output Parameters
+    /// \param arr_out : output array initialized by the input array
+    void operator()(const Device_out* dev_out,
+                    const Device_in* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height);
 };
 
 template <typename FPTYPE_out, typename FPTYPE_in, typename Device_out, typename Device_in>
@@ -112,6 +155,12 @@ struct set_memory_op<FPTYPE, base_device::DEVICE_GPU>
 };
 
 template <typename FPTYPE>
+struct set_memory_2d_op<FPTYPE, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev, FPTYPE* arr, const size_t pitch, const int var, const size_t width, const size_t height);
+};
+
+template <typename FPTYPE>
 struct synchronize_memory_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_GPU>
 {
     void operator()(const base_device::DEVICE_CPU* dev_out,
@@ -137,6 +186,43 @@ struct synchronize_memory_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVIC
                     FPTYPE* arr_out,
                     const FPTYPE* arr_in,
                     const size_t size);
+};
+
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_CPU, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_CPU* dev_out,
+                    const base_device::DEVICE_GPU* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height);
+};
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_CPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev_out,
+                    const base_device::DEVICE_CPU* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height);
+};
+template <typename FPTYPE>
+struct synchronize_memory_2d_op<FPTYPE, base_device::DEVICE_GPU, base_device::DEVICE_GPU>
+{
+    void operator()(const base_device::DEVICE_GPU* dev_out,
+                    const base_device::DEVICE_GPU* dev_in,
+                    FPTYPE* arr_out,
+                    const size_t dpitch,
+                    const FPTYPE* arr_in,
+                    const size_t spitch,
+                    const size_t width,
+                    const size_t height);
 };
 
 template <typename FPTYPE>
@@ -169,6 +255,16 @@ using setmem_dd_op = base_device::memory::set_memory_op<double, base_device::DEV
 using setmem_cd_op = base_device::memory::set_memory_op<std::complex<float>, base_device::DEVICE_GPU>;
 using setmem_zd_op = base_device::memory::set_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
 
+using setmem_sh_2d_op = base_device::memory::set_memory_2d_op<float, base_device::DEVICE_CPU>;
+using setmem_dh_2d_op = base_device::memory::set_memory_2d_op<double, base_device::DEVICE_CPU>;
+using setmem_ch_2d_op = base_device::memory::set_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU>;
+using setmem_zh_2d_op = base_device::memory::set_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU>;
+
+using setmem_sd_2d_op = base_device::memory::set_memory_2d_op<float, base_device::DEVICE_GPU>;
+using setmem_dd_2d_op = base_device::memory::set_memory_2d_op<double, base_device::DEVICE_GPU>;
+using setmem_cd_2d_op = base_device::memory::set_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU>;
+using setmem_zd_2d_op = base_device::memory::set_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU>;
+
 using delmem_sh_op = base_device::memory::delete_memory_op<float, base_device::DEVICE_CPU>;
 using delmem_dh_op = base_device::memory::delete_memory_op<double, base_device::DEVICE_CPU>;
 using delmem_ch_op = base_device::memory::delete_memory_op<std::complex<float>, base_device::DEVICE_CPU>;
@@ -192,6 +288,19 @@ using syncmem_d2d_h2d_op
 using syncmem_d2d_d2h_op
     = base_device::memory::synchronize_memory_op<double, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 
+using syncmem_s2s_h2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<float, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+using syncmem_s2s_h2d_2d_op
+    = base_device::memory::synchronize_memory_2d_op<float, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+using syncmem_s2s_d2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<float, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+using syncmem_d2d_h2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<double, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+using syncmem_d2d_h2d_2d_op
+    = base_device::memory::synchronize_memory_2d_op<double, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+using syncmem_d2d_d2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<double, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+
 using syncmem_c2c_h2h_op
     = base_device::memory::synchronize_memory_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
 using syncmem_c2c_h2d_op
@@ -204,6 +313,19 @@ using syncmem_z2z_h2d_op
     = base_device::memory::synchronize_memory_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
 using syncmem_z2z_d2h_op
     = base_device::memory::synchronize_memory_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+
+using syncmem_c2c_h2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+using syncmem_c2c_h2d_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+using syncmem_c2c_d2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<float>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
+using syncmem_z2z_h2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;
+using syncmem_z2z_h2d_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+using syncmem_z2z_d2h_2d_op
+    = base_device::memory::synchronize_memory_2d_op<std::complex<double>, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 
 using castmem_s2d_h2h_op
     = base_device::memory::cast_memory_op<double, float, base_device::DEVICE_CPU, base_device::DEVICE_CPU>;

--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -60,6 +60,8 @@ Diago_DavSubspace<T, Device>::Diago_DavSubspace(const std::vector<Real>& precond
     {
         resmem_real_op()(this->ctx, this->d_precondition, nbasis_in);
         // syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_precondition, this->precondition.data(), nbasis_in);
+        base_device::memory::resize_memory_op<T, Device>()(this->ctx, this->d_scc, this->nbase_x * this->nbase_x);
+        resmem_real_op()(this->ctx, this->d_eigenvalue, this->nbase_x);
     }
 #endif
 }
@@ -78,6 +80,8 @@ Diago_DavSubspace<T, Device>::~Diago_DavSubspace()
     if (this->device == base_device::GpuDevice)
     {
         delmem_real_op()(this->ctx, this->d_precondition);
+        delmem_complex_op()(this->ctx, this->d_scc);
+        delmem_real_op()(this->ctx, this->d_eigenvalue);
     }
 #endif
 }
@@ -289,29 +293,13 @@ bool Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
                          psi_iter + (nbase) * this->dim,
                          this->dim);
 
-    std::vector<Real> e_temp_cpu(nbase, 0);
-    Real* e_temp_hd = e_temp_cpu.data();
-    if(this->device == base_device::GpuDevice)
-    {
-        e_temp_hd = nullptr;
-        resmem_real_op()(this->ctx, e_temp_hd, nbase);
-    }
-    for (int m = 0; m < notconv; m++)
-    {
-        e_temp_cpu.assign(nbase, (-1.0 * (*eigenvalue_iter)[m]));
-        if (this->device == base_device::GpuDevice)
-        {
-            syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, e_temp_hd, e_temp_cpu.data(), nbase);
-        }
-        vector_mul_vector_op<T, Device>()(this->ctx,
-                                                nbase,
-                                                vcc + m * this->nbase_x,
-                                                vcc + m * this->nbase_x,
-                                                e_temp_hd);
-    }
-    if(this->device == base_device::GpuDevice)
-    {
-        delmem_real_op()(this->ctx, e_temp_hd);
+    if (this->device == base_device::GpuDevice){
+#if defined(__CUDA) || defined(__ROCM)
+        syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_eigenvalue, eigenvalue_iter->data(), this->nbase_x);
+        hsolver::matrixMutiplyVector<T, Device>()(this->ctx, nbase, notconv, vcc, this->nbase_x, this->d_eigenvalue, -1.0, vcc, this->nbase_x);
+#endif
+    }else{
+        hsolver::matrixMutiplyVector<T, Device>()(this->ctx, nbase, notconv, vcc, this->nbase_x, eigenvalue_iter->data(), -1.0, vcc, this->nbase_x);
     }
 
     gemm_op<T, Device>()(this->ctx,
@@ -329,59 +317,20 @@ bool Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
                          psi_iter + nbase * this->dim,
                          this->dim);
 
-    // "precondition!!!"
-    std::vector<Real> pre(this->dim, 0.0);
-    for (int m = 0; m < notconv; m++)
-    {
-        for (size_t i = 0; i < this->dim; i++)
-        {
-            // pre[i] = std::abs(this->precondition[i] - (*eigenvalue_iter)[m]);
-            double x = std::abs(this->precondition[i] - (*eigenvalue_iter)[m]);
-            pre[i] = 0.5 * (1.0 + x + sqrt(1 + (x - 1.0) * (x - 1.0)));
-        }
+    if (this->device == base_device::GpuDevice){
 #if defined(__CUDA) || defined(__ROCM)
-        if (this->device == base_device::GpuDevice)
-        {
-            syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_precondition, pre.data(), this->dim);
-            vector_div_vector_op<T, Device>()(this->ctx,
-                                              this->dim,
-                                              psi_iter + (nbase + m) * this->dim,
-                                              psi_iter + (nbase + m) * this->dim,
-                                              this->d_precondition);
-        }
-        else
+        syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_precondition,this->precondition.data(), this->dim);
+        hsolver::updatePsiByPrecondition<T, Device>()(this->ctx, this->dim, notconv, psi_iter + nbase * this->dim,
+            this->dim, this->d_precondition, this->d_eigenvalue);
 #endif
-        {
-            vector_div_vector_op<T, Device>()(this->ctx,
-                                              this->dim,
-                                              psi_iter + (nbase + m) * this->dim,
-                                              psi_iter + (nbase + m) * this->dim,
-                                              pre.data());
-        }
+    }else{
+        hsolver::updatePsiByPrecondition<T, Device>()(this->ctx, this->dim, notconv, psi_iter + nbase * this->dim,
+            this->dim, this->precondition.data(), eigenvalue_iter->data());
     }
 
     // "normalize!!!" in order to improve numerical stability of subspace diagonalization
-    std::vector<Real> psi_norm(notconv, 0.0);
-    for (size_t i = 0; i < notconv; i++)
-    {
-        psi_norm[i] = dot_real_op<T, Device>()(this->ctx,
-                                               this->dim,
-                                               psi_iter + (nbase + i) * this->dim,
-                                               psi_iter + (nbase + i) * this->dim,
-                                               true);
-        if(psi_norm[i] <= 0.0) 
-        { 
-            ModuleBase::timer::tick("Diago_DavSubspace", "cal_grad");
-            return false;
-        }
-        psi_norm[i] = sqrt(psi_norm[i]);
+    hsolver::normalizeMatrixColumn<T, Device>()(this->ctx, this->dim, notconv, psi_iter + nbase * this->dim, this->dim);
 
-        vector_div_constant_op<T, Device>()(this->ctx,
-                                            this->dim,
-                                            psi_iter + (nbase + i) * this->dim,
-                                            psi_iter + (nbase + i) * this->dim,
-                                            psi_norm[i]);
-    }
 
     hpsi_func(&hphi[nbase * this->dim], psi_iter, this->nbase_x, this->dim, nbase, nbase + notconv - 1);
 
@@ -518,34 +467,10 @@ bool Diago_DavSubspace<T, Device>::diag_zhegvx(const int& nbase,
         if (this->device == base_device::GpuDevice)
         {
 #if defined(__CUDA) || defined(__ROCM)
-            Real* eigenvalue_gpu = nullptr;
-            resmem_real_op()(this->ctx, eigenvalue_gpu, this->nbase_x);
+            base_device::memory::synchronize_memory_op<T, Device, Device>()(this->ctx, this->ctx, this->d_scc, scc, nbase * this->nbase_x);
 
-            syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, eigenvalue_gpu, (*eigenvalue_iter).data(), this->nbase_x);
-
-            T* hcc_gpu = nullptr;
-            T* scc_gpu = nullptr;
-            T* vcc_gpu = nullptr;
-            base_device::memory::resize_memory_op<T, Device>()(this->ctx, hcc_gpu, nbase * nbase);
-            base_device::memory::resize_memory_op<T, Device>()(this->ctx, scc_gpu, nbase * nbase);
-            base_device::memory::resize_memory_op<T, Device>()(this->ctx, vcc_gpu, nbase * nbase);
-            for(int i=0;i<nbase;i++)
-            {
-                base_device::memory::synchronize_memory_op<T, Device, Device>()(this->ctx, this->ctx, hcc_gpu + i * nbase, hcc + i * nbase_x, nbase);
-                base_device::memory::synchronize_memory_op<T, Device, Device>()(this->ctx, this->ctx, scc_gpu + i * nbase, scc + i * nbase_x, nbase);
-            }
-            dngvd_op<T, Device>()(this->ctx, nbase, nbase, hcc_gpu, scc_gpu, eigenvalue_gpu, vcc_gpu, &fail_info);
-            for(int i=0;i<nbase;i++)
-            {
-                base_device::memory::synchronize_memory_op<T, Device, Device>()(this->ctx, this->ctx, vcc + i * nbase_x, vcc_gpu + i * nbase, nbase);
-            }
-            delmem_complex_op()(this->ctx, hcc_gpu);
-            delmem_complex_op()(this->ctx, scc_gpu);
-            delmem_complex_op()(this->ctx, vcc_gpu);
-
-            syncmem_var_d2h_op()(this->cpu_ctx, this->ctx, (*eigenvalue_iter).data(), eigenvalue_gpu, this->nbase_x);
-
-            delmem_real_op()(this->ctx, eigenvalue_gpu);
+            dngvd_op<T, Device>()(this->ctx, nbase, this->nbase_x, hcc, this->d_scc, this->d_eigenvalue, vcc, &fail_info);
+            syncmem_var_d2h_op()(this->cpu_ctx, this->ctx, (*eigenvalue_iter).data(), this->d_eigenvalue, this->nbase_x);
 #endif
         }
         else
@@ -656,40 +581,7 @@ void Diago_DavSubspace<T, Device>::refresh(const int& dim,
     if (this->device == base_device::GpuDevice)
     {
 #if defined(__CUDA) || defined(__ROCM)
-        T* hcc_cpu = nullptr;
-        T* scc_cpu = nullptr;
-        T* vcc_cpu = nullptr;
-        base_device::memory::resize_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx,
-                                                                            hcc_cpu,
-                                                                            this->nbase_x * this->nbase_x,
-                                                                            "DAV::hcc");
-        base_device::memory::resize_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx,
-                                                                            scc_cpu,
-                                                                            this->nbase_x * this->nbase_x,
-                                                                            "DAV::scc");
-        base_device::memory::resize_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx,
-                                                                            vcc_cpu,
-                                                                            this->nbase_x * this->nbase_x,
-                                                                            "DAV::vcc");
-
-        syncmem_d2h_op()(this->cpu_ctx, this->ctx, hcc_cpu, hcc, this->nbase_x * this->nbase_x);
-        syncmem_d2h_op()(this->cpu_ctx, this->ctx, scc_cpu, scc, this->nbase_x * this->nbase_x);
-        syncmem_d2h_op()(this->cpu_ctx, this->ctx, vcc_cpu, vcc, this->nbase_x * this->nbase_x);
-
-        for (int i = 0; i < nbase; i++)
-        {
-            hcc_cpu[i * this->nbase_x + i] = eigenvalue_in_hsolver[i];
-            scc_cpu[i * this->nbase_x + i] = this->one[0];
-            vcc_cpu[i * this->nbase_x + i] = this->one[0];
-        }
-
-        syncmem_h2d_op()(this->ctx, this->cpu_ctx, hcc, hcc_cpu, this->nbase_x * this->nbase_x);
-        syncmem_h2d_op()(this->ctx, this->cpu_ctx, scc, scc_cpu, this->nbase_x * this->nbase_x);
-        syncmem_h2d_op()(this->ctx, this->cpu_ctx, vcc, vcc_cpu, this->nbase_x * this->nbase_x);
-
-        base_device::memory::delete_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx, hcc_cpu);
-        base_device::memory::delete_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx, scc_cpu);
-        base_device::memory::delete_memory_op<T, base_device::DEVICE_CPU>()(this->cpu_ctx, vcc_cpu);
+        hsolver::refreshHccSccVcc<T, Device>()(this->ctx, nbase, hcc, scc, vcc, this->nbase_x, this->d_eigenvalue, this->one[0]);
 #endif
     }
     else

--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -112,15 +112,10 @@ int Diago_DavSubspace<T, Device>::diag_once(const HPsiFunc& hpsi_func,
 
     ModuleBase::timer::tick("Diago_DavSubspace", "first");
 
+    syncmem_complex_2d_op()(this->ctx, this->ctx, this->psi_in_iter, this->dim, psi_in, psi_in_dmax, this->dim, this->n_band);
     for (int m = 0; m < this->n_band; m++)
     {
         unconv[m] = m;
-
-        syncmem_complex_op()(this->ctx,
-                             this->ctx,
-                             this->psi_in_iter + m * this->dim,
-                             psi_in + m * psi_in_dmax,
-                             this->dim);
     }
 
     hpsi_func(this->hphi, this->psi_in_iter, this->notconv, this->dim, 0, this->notconv - 1);
@@ -226,14 +221,7 @@ int Diago_DavSubspace<T, Device>::diag_once(const HPsiFunc& hpsi_func,
                 // estimate of the eigenvectors and set the basis dimension to N;
 
                 // update this->psi_in_iter according to psi_in
-                for (size_t i = 0; i < this->n_band; i++)
-                {
-                    syncmem_complex_op()(this->ctx,
-                                         this->ctx,
-                                         this->psi_in_iter + i * this->dim,
-                                         psi_in + i * psi_in_dmax,
-                                         this->dim);
-                }
+                syncmem_complex_2d_op()(this->ctx, this->ctx, this->psi_in_iter, this->dim, psi_in, psi_in_dmax, this->dim, this->n_band);
 
                 this->refresh(this->dim,
                               this->n_band,
@@ -569,23 +557,25 @@ void Diago_DavSubspace<T, Device>::refresh(const int& dim,
     syncmem_complex_op()(this->ctx, this->ctx, hphi, psi_iter + nband * this->dim, this->dim * nband);
 
     nbase = nband;
-
-    // set hcc/scc/vcc to 0
-    for (size_t i = 0; i < nbase; i++)
-    {
-        setmem_complex_op()(this->ctx, &hcc[this->nbase_x * i], 0, nbase);
-        setmem_complex_op()(this->ctx, &scc[this->nbase_x * i], 0, nbase);
-        setmem_complex_op()(this->ctx, &vcc[this->nbase_x * i], 0, nbase);
-    }
-
     if (this->device == base_device::GpuDevice)
     {
+        // set hcc/scc/vcc to 0
+        setmem_complex_2d_op()(this->ctx, hcc, this->nbase_x, 0, nbase, nbase);
+        setmem_complex_2d_op()(this->ctx, scc, this->nbase_x, 0, nbase, nbase);
+        setmem_complex_2d_op()(this->ctx, vcc, this->nbase_x, 0, nbase, nbase);
 #if defined(__CUDA) || defined(__ROCM)
         hsolver::refreshHccSccVcc<T, Device>()(this->ctx, nbase, hcc, scc, vcc, this->nbase_x, this->d_eigenvalue, this->one[0]);
 #endif
     }
     else
     {
+        // set hcc/scc/vcc to 0
+        for (size_t i = 0; i < nbase; i++)
+        {
+            setmem_complex_op()(this->ctx, &hcc[this->nbase_x * i], 0, nbase);
+            setmem_complex_op()(this->ctx, &scc[this->nbase_x * i], 0, nbase);
+            setmem_complex_op()(this->ctx, &vcc[this->nbase_x * i], 0, nbase);
+        }
         for (int i = 0; i < nbase; i++)
         {
             hcc[i * this->nbase_x + i] = eigenvalue_in_hsolver[i];

--- a/source/module_hsolver/diago_dav_subspace.h
+++ b/source/module_hsolver/diago_dav_subspace.h
@@ -144,6 +144,7 @@ class Diago_DavSubspace : public DiagH<T, Device>
     using resmem_real_op = base_device::memory::resize_memory_op<Real, Device>;
     using delmem_real_op = base_device::memory::delete_memory_op<Real, Device>;
     using setmem_real_op = base_device::memory::set_memory_op<Real, Device>;
+    using setmem_complex_2d_op = base_device::memory::set_memory_2d_op<T, Device>;
 
     using resmem_real_h_op = base_device::memory::resize_memory_op<Real, base_device::DEVICE_CPU>;
     using delmem_real_h_op = base_device::memory::delete_memory_op<Real, base_device::DEVICE_CPU>;
@@ -152,6 +153,7 @@ class Diago_DavSubspace : public DiagH<T, Device>
     using syncmem_var_h2d_op = base_device::memory::synchronize_memory_op<Real, Device, base_device::DEVICE_CPU>;
     using syncmem_var_d2h_op = base_device::memory::synchronize_memory_op<Real, base_device::DEVICE_CPU, Device>;
     using syncmem_complex_op = base_device::memory::synchronize_memory_op<T, Device, Device>;
+    using syncmem_complex_2d_op = base_device::memory::synchronize_memory_2d_op<T, Device, Device>;
     using castmem_complex_op = base_device::memory::cast_memory_op<std::complex<double>, T, Device, Device>;
     using syncmem_h2d_op = base_device::memory::synchronize_memory_op<T, Device, base_device::DEVICE_CPU>;
     using syncmem_d2h_op = base_device::memory::synchronize_memory_op<T, base_device::DEVICE_CPU, Device>;

--- a/source/module_hsolver/diago_dav_subspace.h
+++ b/source/module_hsolver/diago_dav_subspace.h
@@ -83,6 +83,9 @@ class Diago_DavSubspace : public DiagH<T, Device>
     /// Eigenvectors on the reduced basis
     T* vcc = nullptr;
 
+    T* d_scc = nullptr;
+    Real* d_eigenvalue = nullptr;
+
     /// device type of psi
     Device* ctx = {};
     base_device::DEVICE_CPU* cpu_ctx = {};

--- a/source/module_hsolver/kernels/cuda/dngvd_op.cu
+++ b/source/module_hsolver/kernels/cuda/dngvd_op.cu
@@ -218,7 +218,7 @@ struct dngvd_op<T, base_device::DEVICE_GPU>
                     T* V,
                     int* fail_info)
     {
-        assert(nstart == ldh);
+        // assert(nstart == ldh);
         // A to V
         cudaErrcheck(cudaMemcpy(V, A, sizeof(T) * ldh * nstart, cudaMemcpyDeviceToDevice));
         int info = xhegvd_wrapper(CUBLAS_FILL_MODE_UPPER, nstart, V, ldh,

--- a/source/module_hsolver/kernels/cuda/math_kernel_op.cu
+++ b/source/module_hsolver/kernels/cuda/math_kernel_op.cu
@@ -404,6 +404,119 @@ __global__ void matrix_setTo_another_kernel(
     }
 }
 
+template <typename T, typename Real>
+__global__ void refresh_Hcc_Scc_Vcc_kernel(
+        const int n,
+        T *hcc,
+        T *scc,
+        T *vcc,
+        const int ldh,
+        const Real *eigenvalue,
+        const T one)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n)
+    {
+        hcc[i * ldh + i] = eigenvalue[i];
+        scc[i * ldh + i] = one;
+        vcc[i * ldh + i] = one;
+    }
+}
+
+template <typename T, typename Real>
+__global__ void matrix_multiply_vector_kernel(const int m, const int n, T *a, const int lda, const Real *v, const Real alpha, T *c, const int ldc){
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    int col = blockIdx.y * blockDim.y + threadIdx.y;
+    if (col >= n || row >= m) return;
+    c[col * ldc + row] = a[col * lda + row] * v[col] * alpha;
+}
+
+template <typename T, typename Real>
+__global__ void upate_psi_by_precondition_kernel(const int m, const int n, T *psi, const int lda, const Real *precondition, const Real *eigenvalue){
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    int j = blockIdx.y;
+    if (i >= m || j >= n) return;
+
+    Real x = std::abs(precondition[i] - eigenvalue[j]);
+    Real pre = 0.5 * (1.0 + x + sqrt(1 + (x - 1.0) * (x - 1.0)));
+    psi[j * lda + i] = psi[j * lda + i] / pre;
+}
+
+__device__ double complexAbsSquared(cuDoubleComplex z) {
+    return z.x * z.x + z.y * z.y;
+}
+
+template <typename Real>
+__device__ Real warpReduceSum(Real val) {
+    for (int offset = 16; offset > 0; offset /= 2)
+        val += __shfl_down_sync(0xffffffff, val, offset);
+    return val;
+}
+
+template <typename Real>
+__device__ Real blockReduceSum(Real val, volatile Real* shared) {
+    int lane = threadIdx.x % 32;
+    int wid  = threadIdx.x / 32;
+
+    val = warpReduceSum(val);
+
+    if (lane == 0)
+        shared[wid] = val;
+
+    __syncthreads();
+
+    Real sum = 0.0;
+    if (wid == 0) {
+        sum = (threadIdx.x < blockDim.x / 32) ? shared[lane] : 0.0;
+        sum = warpReduceSum(sum);
+        if (lane == 0) shared[0] = sum;
+    }
+
+    __syncthreads();
+    return shared[0];
+}
+
+__device__ double norm_square(thrust::complex<double> val) {
+    double real = val.real();
+    double imag = val.imag();
+    return real * real + imag * imag;
+}
+
+__device__ float norm_square(thrust::complex<float> val) {
+    float real = val.real();
+    float imag = val.imag();
+    return real * real + imag * imag;
+}
+
+__device__ double norm_square(double val){
+    return val * val;
+}
+
+template <typename T, typename Real>
+__global__ void normalize_matrix_column_kernel(int rows, int cols, T* matrix, int lda) {
+    int col = blockIdx.x;
+    if (col >= cols) return;
+
+    int tid = threadIdx.x;
+    int stride = blockDim.x;
+
+    extern __shared__ char s_char[];
+    Real* shared = reinterpret_cast<Real*>(s_char);
+
+    Real local_sum = 0.0;
+    for (int i = tid; i < rows; i += stride) {
+        T val = matrix[col * lda + i];
+        local_sum += norm_square(val);
+    }
+
+    Real l2_sq = blockReduceSum(local_sum, shared);
+    Real norm = sqrt(l2_sq + 1e-20);
+
+    for (int i = tid; i < rows; i += stride) {
+        matrix[col * lda + i] /= norm;
+    }
+}
+
 template <typename T>
 void line_minimize_with_block_op<T, base_device::DEVICE_GPU>::operator()(T* grad_out,
                                                                          T* hgrad_out,
@@ -731,7 +844,7 @@ cublasOperation_t judge_trans_op(bool is_complex, const char& trans, const char*
     {
         return CUBLAS_OP_C;
     }
-    else 
+    else
     {
         ModuleBase::WARNING_QUIT(name, std::string("Unknown trans type ") + trans + std::string(" !"));
     }
@@ -1029,6 +1142,172 @@ void matrixSetToAnother<std::complex<double>, base_device::DEVICE_GPU>::operator
     cudaCheckOnDebug();
 }
 
+template <>
+void refreshHccSccVcc<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  double *hcc,
+                  double *scc,
+                  double *vcc,
+                  const int &ldh,
+                  const double *eigenvalue,
+                  const double& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    refresh_Hcc_Scc_Vcc_kernel<double, double> <<<block, thread >>> (n, hcc, scc, vcc, ldh, eigenvalue, one);
+
+    cudaCheckOnDebug();
+}
+
+template <>
+void refreshHccSccVcc<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  std::complex<float> *hcc,
+                  std::complex<float> *scc,
+                  std::complex<float> *vcc,
+                  const int &ldh,
+                  const float *eigenvalue,
+                  const std::complex<float>& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    refresh_Hcc_Scc_Vcc_kernel<thrust::complex<float>, float> <<<block, thread >>> (n, reinterpret_cast<thrust::complex<float>*>(hcc),
+                    reinterpret_cast<thrust::complex<float>*>(scc), reinterpret_cast<thrust::complex<float>*>(vcc), ldh, eigenvalue,
+                    thrust::complex<float>(one));
+
+    cudaCheckOnDebug();
+}
+
+template <>
+void refreshHccSccVcc<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  std::complex<double> *hcc,
+                  std::complex<double> *scc,
+                  std::complex<double> *vcc,
+                  const int &ldh,
+                  const double *eigenvalue,
+                  const std::complex<double>& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    refresh_Hcc_Scc_Vcc_kernel<thrust::complex<double>, double> <<<block, thread >>> (n, reinterpret_cast<thrust::complex<double>*>(hcc),
+                    reinterpret_cast<thrust::complex<double>*>(scc), reinterpret_cast<thrust::complex<double>*>(vcc), ldh, eigenvalue,
+                    thrust::complex<double>(one));
+
+    cudaCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *a, const int &lda, const double *v, const double alpha, double *c, const int &ldc){
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (m + thread.y - 1) / thread.y, 1);
+    matrix_multiply_vector_kernel<double, double> <<<block, thread >>>(m, n, a, lda,
+    v, alpha, c, ldc);
+    cudaCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *a, const int &lda, const float *v, const float alpha, std::complex<float> *c, const int &ldc){
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (m + thread.y - 1) / thread.y, 1);
+    matrix_multiply_vector_kernel<thrust::complex<float>, float> <<<block, thread >>>(m, n, reinterpret_cast<thrust::complex<float>*>(a), lda,
+    v, alpha, reinterpret_cast<thrust::complex<float>*>(c), ldc);
+    cudaCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *a, const int &lda, const double *v, const double alpha, std::complex<double> *c, const int &ldc)
+{
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (n + thread.y - 1) / thread.y, 1);
+    matrix_multiply_vector_kernel<thrust::complex<double>, double> <<<block, thread >>>(m, n, reinterpret_cast<thrust::complex<double>*>(a), lda,
+    v, alpha, reinterpret_cast<thrust::complex<double>*>(c), ldc);
+    cudaCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *psi,
+                  const int &lda,
+                  const double *precondition,
+                  const double *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    upate_psi_by_precondition_kernel<double, double> <<<block, thread >>>(m, n, psi, lda,
+    precondition, eigenvalue);
+    cudaCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *psi,
+                  const int &lda,
+                  const float *precondition,
+                  const float *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    upate_psi_by_precondition_kernel<thrust::complex<float>, float> <<<block, thread >>>(m, n, reinterpret_cast<thrust::complex<float>*>(psi), lda,
+    precondition, eigenvalue);
+    cudaCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *psi,
+                  const int &lda,
+                  const double *precondition,
+                  const double *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    upate_psi_by_precondition_kernel<thrust::complex<double>, double> <<<block, thread >>>(m, n, reinterpret_cast<thrust::complex<double>*>(psi), lda,
+    precondition, eigenvalue);
+    cudaCheckOnDebug();
+}
+
+template <>
+void normalizeMatrixColumn<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 32) * sizeof(double);
+
+    normalize_matrix_column_kernel<double, double><<<blocksPerGrid, threadsPerBlock, sharedMemSize>>>(m, n, matrix, lda);
+    cudaCheckOnDebug();
+}
+
+template <>
+void normalizeMatrixColumn<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 32) * sizeof(float);
+
+    normalize_matrix_column_kernel<thrust::complex<float>, float><<<blocksPerGrid, threadsPerBlock, sharedMemSize>>>(m, n, reinterpret_cast<thrust::complex<float>*>(matrix), lda);
+    cudaCheckOnDebug();
+
+}
+template <>
+void normalizeMatrixColumn<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 32) * sizeof(double);
+
+    normalize_matrix_column_kernel<thrust::complex<double>, double><<<blocksPerGrid, threadsPerBlock, sharedMemSize>>>(m, n, reinterpret_cast<thrust::complex<double>*>(matrix), lda);
+    cudaCheckOnDebug();
+}
 
 // Explicitly instantiate functors for the types of functor registered.
 template struct dot_real_op<std::complex<float>, base_device::DEVICE_GPU>;
@@ -1039,6 +1318,10 @@ template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GP
 template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<std::complex<float>, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<std::complex<float>, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<std::complex<float>, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<std::complex<float>, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<std::complex<float>, base_device::DEVICE_GPU>;
 
 template struct dot_real_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct calc_grad_with_block_op<std::complex<double>, base_device::DEVICE_GPU>;
@@ -1048,6 +1331,10 @@ template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_G
 template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<std::complex<double>, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<std::complex<double>, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<std::complex<double>, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<std::complex<double>, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __LCAO
 template struct dot_real_op<double, base_device::DEVICE_GPU>;
@@ -1055,6 +1342,10 @@ template struct vector_div_constant_op<double, base_device::DEVICE_GPU>;
 template struct vector_mul_vector_op<double, base_device::DEVICE_GPU>;
 template struct vector_div_vector_op<double, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<double, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<double, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<double, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<double, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<double, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<double, base_device::DEVICE_GPU>;
 #endif
 }  // namespace hsolver

--- a/source/module_hsolver/kernels/math_kernel_op.cpp
+++ b/source/module_hsolver/kernels/math_kernel_op.cpp
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <vector>
 
 namespace hsolver
 {
@@ -331,6 +332,95 @@ struct matrixSetToAnother<T, base_device::DEVICE_CPU>
     }
 };
 
+template <typename T>
+struct refreshHccSccVcc<T, base_device::DEVICE_CPU>
+{
+    using Real = typename GetTypeReal<T>::type;
+    void operator()(const base_device::DEVICE_CPU *d, const int &n,
+                  T *hcc,
+                  T *scc,
+                  T *vcc,
+                  const int &ldh,
+                  const Real *eigenvalue,
+                  const T &one)
+    {
+#ifdef _OPENMP
+#pragma omp parallel for collapse(1) schedule(static, 8192 / sizeof(T))
+#endif
+        for (int i = 0; i < n; i++)
+        {
+            hcc[i * ldh + i] = eigenvalue[i];
+            scc[i * ldh + i] = one;
+            vcc[i * ldh + i] = one;
+        }
+    }
+};
+
+template <typename T>
+struct matrixMutiplyVector<T, base_device::DEVICE_CPU> {
+    using Real = typename GetTypeReal<T>::type;
+    void operator()(const base_device::DEVICE_CPU *d, const int& m, const int &n,
+                  T *a,
+                  const int &lda,
+                  const Real *v,
+                  const Real alpha,
+                  T *c,
+                  const int &ldc){
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2) schedule(static, 8192 / sizeof(T))
+#endif
+        for (int j = 0; j < n; j++){
+            for (int i = 0; i < m; i++){
+                c[j * lda + i] = a[j * lda + i] * v[j] * alpha;
+            }
+        }
+
+    }
+};
+
+template <typename T>
+struct updatePsiByPrecondition<T, base_device::DEVICE_CPU> {
+    using Real = typename GetTypeReal<T>::type;
+    void operator()(const base_device::DEVICE_CPU *d, const int &m, const int &n,
+                  T *psi,
+                  const int &lda,
+                  const Real *precondition,
+                  const Real *eigenvalue){
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2) schedule(static, 8192 / sizeof(T))
+#endif
+        for (int j = 0; j < n; j++){
+            for (int i = 0; i< m; i++){
+                Real x = std::abs(precondition[i] - eigenvalue[j]);
+                Real pre = 0.5 * (1.0 + x + sqrt(1 + (x - 1.0) * (x - 1.0)));
+                psi[j * lda + i] = psi[j * lda + i] / pre;
+            }
+        }
+    }
+};
+
+template <typename T>
+struct normalizeMatrixColumn<T, base_device::DEVICE_CPU> {
+    using Real = typename GetTypeReal<T>::type;
+    void operator()(const base_device::DEVICE_CPU *d, const int &m, const int &n,
+                  T *matrix,
+                  const int &lda){
+
+        std::vector<Real> psi_norm(n, 0.0);
+        for (size_t i = 0; i < n; i++){
+            psi_norm[i] = dot_real_op<T, base_device::DEVICE_CPU>()(d, m, matrix + i * lda, matrix + i * lda, true);
+
+            psi_norm[i] = sqrt(psi_norm[i]);
+            vector_div_constant_op<T, base_device::DEVICE_CPU>()(d,
+                                                                 m,
+                                                                 matrix + i * lda,
+                                                                 matrix + i * lda,
+                                                                 psi_norm[i]);
+        }
+
+    }
+};
+
 // Explicitly instantiate functors for the types of functor registered.
 template struct scal_op<float, base_device::DEVICE_CPU>;
 template struct axpy_op<std::complex<float>, base_device::DEVICE_CPU>;
@@ -343,6 +433,10 @@ template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_CP
 template struct constantvector_addORsub_constantVector_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct matrixTranspose_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct matrixSetToAnother<std::complex<float>, base_device::DEVICE_CPU>;
+template struct refreshHccSccVcc<std::complex<float>, base_device::DEVICE_CPU>;
+template struct matrixMutiplyVector<std::complex<float>, base_device::DEVICE_CPU>;
+template struct updatePsiByPrecondition<std::complex<float>, base_device::DEVICE_CPU>;
+template struct normalizeMatrixColumn<std::complex<float>, base_device::DEVICE_CPU>;
 template struct calc_grad_with_block_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct line_minimize_with_block_op<std::complex<float>, base_device::DEVICE_CPU>;
 
@@ -357,6 +451,10 @@ template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_C
 template struct constantvector_addORsub_constantVector_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct matrixTranspose_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct matrixSetToAnother<std::complex<double>, base_device::DEVICE_CPU>;
+template struct refreshHccSccVcc<std::complex<double>, base_device::DEVICE_CPU>;
+template struct matrixMutiplyVector<std::complex<double>, base_device::DEVICE_CPU>;
+template struct updatePsiByPrecondition<std::complex<double>, base_device::DEVICE_CPU>;
+template struct normalizeMatrixColumn<std::complex<double>, base_device::DEVICE_CPU>;
 template struct calc_grad_with_block_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct line_minimize_with_block_op<std::complex<double>, base_device::DEVICE_CPU>;
 
@@ -370,6 +468,10 @@ template struct vector_div_constant_op<double, base_device::DEVICE_CPU>;
 template struct vector_div_vector_op<double, base_device::DEVICE_CPU>;
 template struct matrixTranspose_op<double, base_device::DEVICE_CPU>;
 template struct matrixSetToAnother<double, base_device::DEVICE_CPU>;
+template struct refreshHccSccVcc<double, base_device::DEVICE_CPU>;
+template struct matrixMutiplyVector<double, base_device::DEVICE_CPU>;
+template struct updatePsiByPrecondition<double, base_device::DEVICE_CPU>;
+template struct normalizeMatrixColumn<double, base_device::DEVICE_CPU>;
 template struct constantvector_addORsub_constantVector_op<double, base_device::DEVICE_CPU>;
 #endif
 } // namespace hsolver

--- a/source/module_hsolver/kernels/math_kernel_op.h
+++ b/source/module_hsolver/kernels/math_kernel_op.h
@@ -295,6 +295,95 @@ template <typename T, typename Device> struct matrixSetToAnother {
                   T *B, const int &LDB);
 };
 
+template <typename T, typename Device> struct refreshHccSccVcc {
+    using Real = typename GetTypeReal<T>::type;
+  /// @brief refresh hcc scc vcc
+  ///
+  /// Input Parameters
+  /// \param d : the type of computing device
+  /// \param n : first dimension of matrix
+  /// \param ldh : leading dimension of hcc, scc, vcc
+  /// \param nbase : matrix size
+  /// \param eigenvalue : input eigenvalue
+  /// \param one : constant one
+  ///
+  /// Output Parameters
+  /// \param hcc : output matrix hcc
+  /// \param scc : output matrix scc
+  /// \param vcc : output matrix vcc
+  void operator()(const Device *d, const int &n,
+                  T *hcc,
+                  T *scc,
+                  T *vcc,
+                  const int &ldh,
+                  const Real *eigenvalue,
+                  const T& one);
+};
+
+template <typename T, typename Device> struct matrixMutiplyVector {
+    using Real = typename GetTypeReal<T>::type;
+  /// @brief A * v * beta by each column
+  ///
+  /// Input Parameters
+  /// \param d : the type of computing device
+  /// \param m : row number
+  /// \param n : column number
+  /// \param a : input matrix
+  /// \param lda : leading dimension of matrix a
+  /// \param v : input vector
+  /// \param alpha : factor
+  /// \param ldc : leading dimension of matrix a
+  ///
+  /// Output Parameters
+  /// \param c : output matrix
+  void operator()(const Device *d, const int &m, const int &n,
+                  T *a,
+                  const int &lda,
+                  const Real *v,
+                  const Real alpha,
+                  T *c,
+                  const int &ldc);
+};
+
+template <typename T, typename Device> struct updatePsiByPrecondition {
+    using Real = typename GetTypeReal<T>::type;
+  /// @brief
+  ///
+  /// Input Parameters
+  /// \param d : the type of computing device
+  /// \param m : row number
+  /// \param n : column number
+  /// \param psi : input matrix
+  /// \param lda : leading dimension of matrix psi
+  /// \param precondition : input vector
+  /// \param eigenvalue : input vector
+  ///
+  /// Output Parameters
+  /// \param psi : output matrix
+  void operator()(const Device *d, const int &m, const int &n,
+                  T *psi,
+                  const int &lda,
+                  const Real *precondition,
+                  const Real *eigenvalue);
+};
+
+template <typename T, typename Device> struct normalizeMatrixColumn {
+  /// @brief normalize matrix each column
+  ///
+  /// Input Parameters
+  /// \param d : the type of computing device
+  /// \param m : row number
+  /// \param n : column number
+  /// \param matrix : input matrix
+  /// \param lda : leading dimension of matrix matrix
+  ///
+  /// Output Parameters
+  /// \param matrix : output matrix
+  void operator()(const Device *d, const int &m, const int &n,
+                  T *matrix,
+                  const int &lda);
+};
+
 #if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
 
 template <typename T>
@@ -358,6 +447,43 @@ template <typename T> struct matrixSetToAnother<T, base_device::DEVICE_GPU> {
                   const int &LDA,
                   T *B, // output
                   const int &LDB);
+};
+
+template <typename T> struct refreshHccSccVcc<T, base_device::DEVICE_GPU> {
+  using Real = typename GetTypeReal<T>::type;
+  void operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  T *hcc,
+                  T *scc,
+                  T *vcc,
+                  const int &ldh,
+                  const Real *eigenvalue,
+                  const T &one);
+};
+
+template <typename T> struct matrixMutiplyVector<T, base_device::DEVICE_GPU> {
+  using Real = typename GetTypeReal<T>::type;
+  void operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  T *a,
+                  const int &lda,
+                  const Real *v,
+                  const Real alpha,
+                  T *c,
+                  const int &ldc);
+};
+
+template <typename T> struct updatePsiByPrecondition<T, base_device::DEVICE_GPU> {
+  using Real = typename GetTypeReal<T>::type;
+  void operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  T *psi,
+                  const int &lda,
+                  const Real *precondition,
+                  const Real *eigenvalue);
+};
+
+template <typename T> struct normalizeMatrixColumn<T, base_device::DEVICE_GPU> {
+  void operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  T *matrix,
+                  const int &lda);
 };
 
 void createGpuBlasHandle();

--- a/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -108,7 +108,7 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
                                                                         int* fail_info)
 {
     // copied from ../cuda/dngvd_op.cu, "dngvd_op"
-    assert(nstart == ldh);
+    // assert(nstart == ldh);
 
     hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<float>) * ldh * nstart, hipMemcpyDeviceToDevice));
     // now vcc contains hcc
@@ -178,7 +178,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
                                                                          int* fail_info)
 {
     // copied from ../cuda/dngvd_op.cu, "dngvd_op"
-    assert(nstart == ldh);
+    // assert(nstart == ldh);
 
     // save a copy of scc in case the diagonalization fails
     std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
@@ -241,7 +241,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
                                                               hcc.data(),
                                                               scc.data(),
                                                               eigenvalue.data(),
-                                                              vcc.data(), 
+                                                              vcc.data(),
                                                               fail_info);
     hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice));
     hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));*/

--- a/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
@@ -327,6 +327,120 @@ __global__ void matrix_setTo_another_kernel(
     }
 }
 
+template <typename T, typename Real>
+__global__ void refresh_Hcc_Scc_Vcc_kernel(
+        const int n,
+        T *hcc,
+        T *scc,
+        T *vcc,
+        const int ldh,
+        const Real *eigenvalue,
+        const T one)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n)
+    {
+        hcc[i * ldh + i] = eigenvalue[i];
+        scc[i * ldh + i] = one;
+        vcc[i * ldh + i] = one;
+    }
+}
+
+template <typename T, typename Real>
+__global__ void matrix_multiply_vector_kernel(const int m, const int n, T *a, const int lda, const Real *v, const Real alpha, T *c, const int ldc){
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    int col = blockIdx.y * blockDim.y + threadIdx.y;
+    if (col >= n || row >= m) return;
+    c[col * ldc + row] = a[col * lda + row] * v[col] * alpha;
+}
+
+template <typename T, typename Real>
+__global__ void upate_psi_by_precondition_kernel(const int m, const int n, T *psi, const int lda, const Real *precondition, const Real *eigenvalue){
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    int j = blockIdx.y;
+    if (i >= m || j >= n) return;
+
+    Real x = std::abs(precondition[i] - eigenvalue[j]);
+    Real pre = 0.5 * (1.0 + x + sqrt(1 + (x - 1.0) * (x - 1.0)));
+    psi[j * lda + i] = psi[j * lda + i] / pre;
+}
+
+__device__ double complexAbsSquared(cuDoubleComplex z) {
+    return z.x * z.x + z.y * z.y;
+}
+
+template <typename Real>
+__device__ Real warpReduceSum(Real val) {
+    for (int offset = 32; offset > 0; offset /= 2)
+        val += __shfl_down_sync(0xffffffffffffffff, val, offset);
+    return val;
+}
+
+template <typename Real>
+__device__ Real blockReduceSum(Real val, volatile Real* shared) {
+    int lane = threadIdx.x % 64;
+    int wid  = threadIdx.x / 64;
+
+    val = warpReduceSum(val);
+
+    if (lane == 0)
+        shared[wid] = val;
+
+    __syncthreads();
+
+    Real sum = 0.0;
+    if (wid == 0) {
+        sum = (threadIdx.x < blockDim.x / 64) ? shared[lane] : 0.0;
+        sum = warpReduceSum(sum);
+        if (lane == 0) shared[0] = sum;
+    }
+
+    __syncthreads();
+    return shared[0];
+}
+
+__device__ double norm_square(thrust::complex<double> val) {
+    double real = val.real();
+    double imag = val.imag();
+    return real * real + imag * imag;
+}
+
+__device__ float norm_square(thrust::complex<float> val) {
+    float real = val.real();
+    float imag = val.imag();
+    return real * real + imag * imag;
+}
+
+__device__ double norm_square(double val){
+    return val * val;
+}
+
+template <typename T, typename Real>
+__launch_bounds__(1024)
+__global__ void normalize_matrix_column_kernel(int rows, int cols, T* matrix, int lda) {
+    int col = blockIdx.x;
+    if (col >= cols) return;
+
+    int tid = threadIdx.x;
+    int stride = blockDim.x;
+
+    extern __shared__ char s_char[];
+    Real* shared = reinterpret_cast<Real*>(s_char);
+
+    Real local_sum = 0.0;
+    for (int i = tid; i < rows; i += stride) {
+        T val = matrix[col * lda + i];
+        local_sum += norm_square(val);
+    }
+
+    Real l2_sq = blockReduceSum(local_sum, shared);
+    Real norm = sqrt(l2_sq + 1e-20);
+
+    for (int i = tid; i < rows; i += stride) {
+        matrix[col * lda + i] /= norm;
+    }
+}
+
 template <typename T>
 void line_minimize_with_block_op<T, base_device::DEVICE_GPU>::operator()(T* grad_out,
                                                                          T* hgrad_out,
@@ -655,7 +769,7 @@ hipblasOperation_t judge_trans_op(bool is_complex, const char& trans, const char
     {
         return HIPBLAS_OP_C;
     }
-    else 
+    else
     {
         ModuleBase::WARNING_QUIT(name, std::string("Unknown trans type ") + trans + std::string(" !"));
     }
@@ -942,7 +1056,172 @@ void matrixSetToAnother<std::complex<double>, base_device::DEVICE_GPU>::operator
     hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_setTo_another_kernel<thrust::complex<double>>), dim3(block), dim3(thread), 0, 0, n, LDA, LDB, reinterpret_cast<const thrust::complex<double>*>(A), reinterpret_cast<thrust::complex<double>*>(B));
     hipCheckOnDebug();
 }
+template <>
+void refreshHccSccVcc<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  double *hcc,
+                  double *scc,
+                  double *vcc,
+                  const int &ldh,
+                  const double *eigenvalue,
+                  const double& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(refresh_Hcc_Scc_Vcc_kernel<double, double>), dim3(block), dim3(thread), 0, 0, n, hcc, scc, vcc, ldh, eigenvalue, one);
 
+    hipCheckOnDebug();
+}
+
+template <>
+void refreshHccSccVcc<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  std::complex<float> *hcc,
+                  std::complex<float> *scc,
+                  std::complex<float> *vcc,
+                  const int &ldh,
+                  const float *eigenvalue,
+                  const std::complex<float>& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(refresh_Hcc_Scc_Vcc_kernel<thrust::complex<float>, float>), dim3(block), dim3(thread), 0, 0, n, reinterpret_cast<thrust::complex<float>*>(hcc),
+                    reinterpret_cast<thrust::complex<float>*>(scc), reinterpret_cast<thrust::complex<float>*>(vcc), ldh, eigenvalue,
+                    thrust::complex<float>(one));
+
+    hipCheckOnDebug();
+}
+
+template <>
+void refreshHccSccVcc<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &n,
+                  std::complex<double> *hcc,
+                  std::complex<double> *scc,
+                  std::complex<double> *vcc,
+                  const int &ldh,
+                  const double *eigenvalue,
+                  const std::complex<double>& one)
+{
+    int thread = 512;
+    int block = (n + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(refresh_Hcc_Scc_Vcc_kernel<thrust::complex<double>, double>), dim3(block), dim3(thread), 0, 0, n, reinterpret_cast<thrust::complex<double>*>(hcc),
+                    reinterpret_cast<thrust::complex<double>*>(scc), reinterpret_cast<thrust::complex<double>*>(vcc), ldh, eigenvalue,
+                    thrust::complex<double>(one));
+
+    hipCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *a, const int &lda, const double *v, const double alpha, double *c, const int &ldc){
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (m + thread.y - 1) / thread.y, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_multiply_vector_kernel<double, double>), block, thread, 0, 0, m, n, a, lda,
+    v, alpha, c, ldc);
+    hipCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *a, const int &lda, const float *v, const float alpha, std::complex<float> *c, const int &ldc){
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (m + thread.y - 1) / thread.y, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_multiply_vector_kernel<thrust::complex<float>, float>), block, thread, 0, 0, m, n, reinterpret_cast<thrust::complex<float>*>(a), lda,
+    v, alpha, reinterpret_cast<thrust::complex<float>*>(c), ldc);
+    hipCheckOnDebug();
+}
+
+template <>
+void matrixMutiplyVector<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *a, const int &lda, const double *v, const double alpha, std::complex<double> *c, const int &ldc)
+{
+    dim3 thread(16, 16, 1);
+    dim3 block((m + thread.x - 1) / thread.x, (n + thread.y - 1) / thread.y, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_multiply_vector_kernel<thrust::complex<double>, double>), block, thread, 0, 0, m, n, reinterpret_cast<thrust::complex<double>*>(a), lda,
+    v, alpha, reinterpret_cast<thrust::complex<double>*>(c), ldc);
+    hipCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *psi,
+                  const int &lda,
+                  const double *precondition,
+                  const double *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(upate_psi_by_precondition_kernel<double, double>), block, thread, 0, 0, m, n, psi, lda,
+    precondition, eigenvalue);
+    hipCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *psi,
+                  const int &lda,
+                  const float *precondition,
+                  const float *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(upate_psi_by_precondition_kernel<thrust::complex<float>, float>), block, thread, 0, 0, m, n, reinterpret_cast<thrust::complex<float>*>(psi), lda,
+    precondition, eigenvalue);
+    hipCheckOnDebug();
+}
+
+template <>
+void updatePsiByPrecondition<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *psi,
+                  const int &lda,
+                  const double *precondition,
+                  const double *eigenvalue)
+{
+    dim3 thread(256);
+    dim3 block((m + thread.x - 1) / thread.x, n, 1);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(upate_psi_by_precondition_kernel<thrust::complex<double>, double>), block, thread, 0, 0, m, n, reinterpret_cast<thrust::complex<double>*>(psi), lda,
+    precondition, eigenvalue);
+    hipCheckOnDebug();
+}
+
+template <>
+void normalizeMatrixColumn<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  double *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 64) * sizeof(double);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(normalize_matrix_column_kernel<double, double>), dim3(blocksPerGrid), dim3(threadsPerBlock), sharedMemSize, 0, m, n, matrix, lda);
+    hipCheckOnDebug();
+}
+
+template <>
+void normalizeMatrixColumn<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<float> *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 64) * sizeof(float);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(normalize_matrix_column_kernel<thrust::complex<float>, float>), dim3(blocksPerGrid), dim3(threadsPerBlock), sharedMemSize, 0, m, n, reinterpret_cast<thrust::complex<float>*>(matrix), lda);
+    hipCheckOnDebug();
+
+}
+template <>
+void normalizeMatrixColumn<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU *d, const int &m, const int &n,
+                  std::complex<double> *matrix,
+                  const int &lda)
+{
+    int threadsPerBlock = 256;
+    int blocksPerGrid = n;
+
+    int sharedMemSize = (threadsPerBlock / 64) * sizeof(double);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(normalize_matrix_column_kernel<thrust::complex<double>, double>), dim3(blocksPerGrid), dim3(threadsPerBlock), sharedMemSize, 0, m, n, reinterpret_cast<thrust::complex<double>*>(matrix), lda);
+    hipCheckOnDebug();
+}
 
 
 // Explicitly instantiate functors for the types of functor registered.
@@ -954,6 +1233,10 @@ template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GP
 template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<std::complex<float>, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<std::complex<float>, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<std::complex<float>, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<std::complex<float>, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<std::complex<float>, base_device::DEVICE_GPU>;
 
 template struct dot_real_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct calc_grad_with_block_op<std::complex<double>, base_device::DEVICE_GPU>;
@@ -963,6 +1246,10 @@ template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_G
 template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<std::complex<double>, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<std::complex<double>, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<std::complex<double>, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<std::complex<double>, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __LCAO
 template struct dot_real_op<double, base_device::DEVICE_GPU>;
@@ -970,6 +1257,10 @@ template struct vector_div_constant_op<double, base_device::DEVICE_GPU>;
 template struct vector_mul_vector_op<double, base_device::DEVICE_GPU>;
 template struct vector_div_vector_op<double, base_device::DEVICE_GPU>;
 template struct matrixSetToAnother<double, base_device::DEVICE_GPU>;
+template struct refreshHccSccVcc<double, base_device::DEVICE_GPU>;
+template struct matrixMutiplyVector<double, base_device::DEVICE_GPU>;
+template struct updatePsiByPrecondition<double, base_device::DEVICE_GPU>;
+template struct normalizeMatrixColumn<double, base_device::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<double, base_device::DEVICE_GPU>;
 #endif
 }  // namespace hsolver


### PR DESCRIPTION
1. Fuse Diago_DavSubspace::cal_grad's GPU operator
2. Port CPU computations of Diago_DavSubspace::cal_grad to GPU
3. Reduce memory copies in Diago_DavSubspace::diag_zhegvx